### PR TITLE
Fix frozen ADS-B positions on delay-Doppler map

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -98,15 +98,10 @@ const process_adsb2dd = async () => {
       continue;
     }
 
-    // check that ADS-B data has updated
-    if (json.now === dict[key]['timestamp']) {
-      continue;
-    }
-
     // core processing
     adsb2dd(key, json);
 
-    // Update the timestamp to prevent reprocessing the same data
+    // Update the timestamp for tracking
     dict[key]['timestamp'] = json.now;
 
     // remove key after inactivity


### PR DESCRIPTION
## Summary

Fixes #1 - Resolves the issue where ADS-B truth data (green dots) appeared frozen on the delay-Doppler map while radar detections (orange) continued updating normally.

## Problem

The global timestamp check was blocking ALL aircraft processing when the ADS-B feed's `json.now` timestamp didn't change, even though individual aircraft positions were updating. This caused the visualization to freeze.

## Solution

Removed the aggressive feed-level timestamp gate and rely on the existing per-aircraft position check (lines 160-165) which:
- ✅ Prevents redundant processing for aircraft that haven't moved
- ✅ Allows updates when positions change, regardless of feed timestamp
- ✅ Maintains the same efficiency without blocking legitimate updates

## Testing

Tested with parallel comparison:
- **OLD code**: Aircraft positions froze when `json.now` was constant
- **NEW code**: Aircraft positions continued updating correctly

The per-aircraft gating ensures no redundant processing occurs.

## Changes

- Removed global timestamp check (5 lines)
- Updated comment to reflect new behavior (1 line)

Total: **-5 lines, +1 line** (minimal, focused fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>