### PR TITLE
Add GitHub Actions workflows for Docker build and release

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,0 +1,92 @@
+name: docker-build
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag (e.g., v1.0.0, dev)"
+        required: true
+        default: dev
+      publish:
+        description: "Push to GHCR?"
+        required: true
+        default: "false"
+        type: choice
+        options: ["false","true"]
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      publish:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions: { contents: read, packages: write }
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build and load adsb2dd
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/arm64
+          push: false
+          load: true
+          tags: adsb2dd:${{ inputs.tag }}
+          cache-from: type=gha,scope=adsb2dd
+          cache-to: type=gha,mode=max,scope=adsb2dd
+          labels: |
+            org.opencontainers.image.source=${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Export image to tarball
+        run: |
+          docker save adsb2dd:${{ inputs.tag }} -o /tmp/adsb2dd.tar
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: adsb2dd-image
+          path: /tmp/adsb2dd.tar
+          retention-days: 1
+
+  publish:
+    needs: build
+    if: ${{ inputs.publish == 'true' }}
+    runs-on: ubuntu-latest
+    permissions: { contents: read, packages: write }
+
+    steps:
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download image
+        uses: actions/download-artifact@v4
+        with:
+          name: adsb2dd-image
+          path: /tmp
+
+      - name: Load and push adsb2dd
+        run: |
+          docker load -i /tmp/adsb2dd.tar
+          docker tag adsb2dd:${{ inputs.tag }} ghcr.io/offworldlabs/adsb2dd:${{ inputs.tag }}
+          docker push ghcr.io/offworldlabs/adsb2dd:${{ inputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., v1.0.0)'
+        required: true
+
+jobs:
+  build-and-publish:
+    uses: ./.github/workflows/docker_build.yml
+    with:
+      tag: ${{ github.event_name == 'push' && github.ref_name || inputs.version }}
+      publish: "true"
+
+  create-release:
+    needs: build-and-publish
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions: { contents: write }
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
+          body: |
+            ## Docker Image
+
+            The adsb2dd Docker image has been published to GitHub Container Registry:
+
+            ```bash
+            docker pull ghcr.io/offworldlabs/adsb2dd:${{ github.ref_name }}
+            ```
+
+            ### What's Changed
+            See the commit history for details.
+          draft: false
+          prerelease: false


### PR DESCRIPTION
Adds automated CI/CD to build and publish ARM64 images to GHCR.

**Changes**
docker_build.yml: Build and publish to ghcr.io/offworldlabs/adsb2dd
release.yml: Auto-release on version tags (v*.*.*)

**Usage**

git tag v0.1.0
git push origin v0.1.0